### PR TITLE
解决：npm install时keygen报错ERR_INVALID_ARG_TYPE

### DIFF
--- a/script/keygen.js
+++ b/script/keygen.js
@@ -13,5 +13,5 @@ if (!fs.existsSync(target)) {
 }
 
 function writeKey () {
-  fs.writeFileSync(target, Array.prototype.map.call(crypto.randomBytes(32), (v => ('0x' + ('0' + v.toString(16)).slice(-2)))))
+  fs.writeFileSync(target, Array.prototype.map.call(crypto.randomBytes(32), (v => ('0x' + ('0' + v.toString(16)).slice(-2)))).toString())
 }


### PR DESCRIPTION
解决npm install报以下错误
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Array
解决方法：转String再写入